### PR TITLE
Convert to HTML form (gh table version)

### DIFF
--- a/checklist.css
+++ b/checklist.css
@@ -1,0 +1,135 @@
+
+body {
+  font-family: sans-serif;
+  line-height: 1.5;
+  font-size: 1.2em;
+  max-width: 60rem;
+  width: 96vw;
+  margin: auto;
+  padding-bottom: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border: 1px solid #ccc;
+  vertical-align: top;
+  font-size: 1rem;
+  text-align: left;
+}
+td a,
+summary a {
+  text-decoration: underline;
+}
+
+
+fieldset {
+  border: 1px solid;
+  border-radius: 6px;
+  padding: 2rem;
+  margin-bottom: 1rem;
+}
+
+legend {
+  font-weight: bold;
+}
+
+input[type="radio"] {
+  margin-right: 0.5rem;
+}
+
+button[type="submit"] {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: 1px solid currentColor;
+  margin-inline-end: 0.5em;
+  border-radius: 4px;
+  cursor: pointer;
+  background: none;
+}
+
+fieldset details {
+  margin-top: 1rem;
+}
+
+details fieldset {
+  margin-top: 0.5em;
+}
+
+input[type="text"] {
+  padding: 0.5rem;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+#spec-url-desc {
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.grid-2c {
+  display: grid;
+  grid-template-columns: min-content auto;
+  align-items: center;
+  gap: 1.5em;
+  margin-block-end: 1em;
+}
+
+*:focus,
+input:hover,
+button:hover,
+a:hover {
+  outline: 2px solid currentColor;
+  outline-offset: 0.15em;
+}
+
+.note {
+font-size: 0.9em;
+}
+
+td details {
+  margin: 0; 
+}
+
+td summary {
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 0.4em; 
+}
+
+td summary::-webkit-details-marker {
+  display: initial; 
+}
+
+td details p {
+  margin: 0.6em 0 0 1.5em; 
+  padding-right: 1em;       
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+td.met-column {
+  vertical-align: top;  
+  width: 7em;            
+}
+
+td.met-column label {
+  display: block;       
+  margin-bottom: 0.4em;
+  font-weight: normal;
+}
+
+th[scope="row"] {
+  font-weight: normal;
+}
+
+th[scope="row"] summary {
+  font-weight: bold;
+}

--- a/checklist.html
+++ b/checklist.html
@@ -1,521 +1,2200 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-	<head>
-		<title>[DRAFT] FAST Checklist</title>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-		<link href="https://www.w3.org/StyleSheets/TR/base" rel="stylesheet" />
-		<style type="text/css">
-			@counter-style checklist
-				 {
-					system: cyclic;
-					symbols: ☐;
-					suffix: " ";
-				}
-			
-			.checklist
-			{
-				list-style-type: checklist;
-				
-			}
-			.checklist ul
-			{
-				list-style-type: disc;
-			}
-			th,
-			td{
-				border: thin dotted grey;
-				border-collapse: collapse;
-				padding: .5ex;
-			}
-			table,
-			tbody{
-				border: medium solid black;
-				border-collapse: collapse;
-			}
-			th{
-				text-align: left;
-			}
-			th[scope = rowgroup]{
-				text-align: center;
-				background-color: black;
-				color: white;
-			}
-			th[scope = rowgroup] a:link,
-			th[scope = rowgroup] a:hover,
-			th[scope = rowgroup] a:active{
-				color: teal;
-			}
-			th[scope = rowgroup] a:visited{
-				color: aqua;
-			}
-			td:first-child::before{
-				content: "☐ ";
-			}</style>
-	</head>
-	<body>
-		<h1>[DRAFT] <abbr title="Framework for Accessibility in the Specification of Technologies">FAST</abbr> Checklist</h1>
-		<p>This is a draft checklist to support <a href="./">Framework for Accessibility in the Specification of Technologies (FAST)</a> prepared by the <a href="http://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a>. The goal of <abbr title="Framework for Accessibility in the Specification of Technologies">FAST</abbr> is to describe the features that web technologies should provide to ensure it is possible to create content that is accessible to users with disabilities. The full framework references an analysis of user requirements, describes how technologies, content authoring, and user agents work together to meet these needs, and provides comprehensive guidance to technology developers. This checklist extracts that information at a high level to aid in self-review of technologies. Specification developers can use this to help ensure the technology will address features likely to be raised during horizontal review from accessibility proponents.</p>
-		<p>Web technologies address a variety of needs, and play a variety of roles in web accessibility. Content languages describe primary content, styling languages impact presentation, APIs enable manipulation and data interchange, and protocols tie it all together. Each of these types of technologies can impact accessibility. </p>
-		<p>This checklist is organized by types of features that a technology may provide. If the technology provides such a feature, the checklist items under the heading are applicable and should be examined. If the technology does not provide such a feature, the checklist items under the heading are not applicable and can be passed over.</p>
-		<table>
-			<caption></caption>
-			<thead>
-				<tr>
-					<th scope="col">Checkpoint</th>
-					<th scope="col">Explanation</th>
-					<th scope="col">References</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology allows visual rendering of content</th>
-				</tr>
-				<tr>
-					<td>There is a defined way for a non-visual rendering to be created. </td>
-					<td>Content is frequently authored with visual rendering the primary consideration. Some technologies, such as image formats, explicitly focus on visual rendering. Some users are not able to access visual content, and must use other forms of the content, such as text or audio. Content that is well-structured allows automated conversion into alternate formats, or content can provide explicit non-visual alternatives. Image and video technologies can and should provide support for automated transformation or for alternative versions as appropriate. Other technologies that are not as explicitly visual but that are likely to be rendered visually, such as text formats and often structured data, need to ensure that non-visual rendering can be as easily achieved as visual rendering.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Content can be resized.</td>
-					<td>Many users need content to be displayed larger than the default, not just because of un-sharp vision but also to mitigate other visual perception difficulties such as difficulty separating foreground from background. Depending on device and situation, content can also be displayed smaller than the author expects, so needs to be resizeable even if the intended default size is suitable. Technologies should provide features to allow user resize, without experiencing problems such as pixelation, clipping, excessive scrolling, etc. Support for resizing therefore requires a variety of features to be enabled by the technology.</td>
-					<td><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale">WCAG 2.0 Resize text</a></td>
-				</tr>
-				<tr>
-					<td>Luminosity and hue contrast can adapt to user requirements.</td>
-					<td>Users with color vision deficits and other visual impairments have more difficulty separating certain foreground from background colors than average. The <a href="https://www.w3.org/TR/WCAG20/#contrast-ratiodef">WCAG 2.0 luminosity contrast ratio</a> describes a way to calculate this contrast, but sometimes even content that passes the guidelines is insufficient. Technologies should provide ways to obtain increase or customized contrast, e.g., via a "high contrast mode".</td>
-					<td><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast">WCAG 2.0 Contrast (minimum)</a><br /><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">WCAG 2.0 Contrast (enhanced)</a></td>
-				</tr>
-				<tr>
-					<td>Text presentation attributes can be changed. </td>
-					<td>Some users with visual impairments and learning disabilities find that customizing text presentation improves their ability to distinguish letters, track lines, etc. Technologies should provide features allowing users to customize typeface, font weight, font style, line / word / letter spacing, margins, line length, justification.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Visual presentation of pointers and cursors can be adjusted.</td>
-					<td>Sometimes pointer and cursor indicators are difficult for users to distinguish and locate, and incessant animation, even simple blinking, can be excessively distracting for some users. Technologies that define pointer and cursor indicators should provide features for user to customize size, color, and animation.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Changing content presentation does not render it unreadable. </td>
-					<td>Many accessibility requirements come down to allowing users to customize presentation. When presentation is changed in a way the author or designer did not anticipate, unexpected side effects often appear that create new problems. A frequent situation is when content is resized but the region for the content is not, causing the content to be clipped. Another is when regions resize but do not reposition, making it difficult to use the content at the new scale. Change of font attributes sometimes leads to a similar problem, such as when users change to a heavier font but the space allocated for characters does not increase. Technologies should provide features to ensure that change of display attributes does not create unintended side effects.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Technology does not allow blinking or flashing of content, or provides a feature for users to quickly turn it off or permanently disable it.</td>
-					<td>Technologies should not provide features that allow authors to create content that <a href="https://www.w3.org/TR/WCAG20/#blinksdef">blinks</a> (which can be excessively distracting) or <a href="https://www.w3.org/TR/WCAG20/#flash-def">flashes</a> (which can be medically disastrous). However, technologies that provide general animation features (even simple ones) may be unable to rule out author usages that create these effects. It is important for such technologies to provide a feature for users to stop animation, or prevent it until requested. More complex technologies should also provide means to mark potentially problematic content, warn users who have opted into the warning, and give users the option to skip or suppress problematic regions of content.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>It is possible to make navigation order correspond to the visual presentation.</td>
-					<td>Flexible display mechanisms can cause content to appear in unpredicted locations. This is often a good feature as it allows optimization of display. However, the navigation order of such content sometimes does not match the perceived order, and users have difficulty using linear (i.e., keyboard-based) navigation effectively. Technologies should provide features to ensure when the visual order of content changes, the interaction order changes to match.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides author control over color</th>
-				</tr>
-				<tr>
-					<td>There is a mechanism for users to override colors of text and user interface components. </td>
-					<td>Custom color settings benefits not only users with visual perception impairments, but also users who can be distracted by certain colors or combinations. Technologies should provide features to allow users to set their own colors or contrast for text (including background) and standard user interface components. </td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>There is a feature for authors to define semantically available "color classes" that users can easily map to custom colors, and give preference to this vs. coloring objects individually. </td>
-					<td>Allowing user override of author design is most effective when the technology provides rich semantics for content, on which author or default colors are based, that can be easily recolored in a meaningful manner. Technologies should define semantics, or a way for authors to define and communicate the semantics they use, to allow most effective recoloring with minimal advance knowledge of site implementation.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>There is a feature for users to choose color schemata that work for them. </td>
-					<td>Content authors are frequently concerned with branding, and want to ensure that the color scheme of content communicates the brand. But when the color scheme makes content inaccessible to users this goal can be counter-productive. Technologies can increase author control and user accessibility by providing a way for authors to define multiple color schemes, allowing more accessible schemes still to partake in the branding process, and allowing users to choose from among available schemes. </td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>The foreground and background color of an object can be reported to the user via AT. </td>
-					<td>Experienced color of content is frequently the way users refer to it; for instance in "redlined" text people may say "find my edits in red". Users of assistive technologies who cannot perceive the color directly therefore still have a need to know the color in order to interact with others. Therefore, technologies should define a way for foreground and background color to be reported to assistive technologies and easily searched.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>There are ways to set foreground and background colors separately for all objects. </td>
-					<td>Color contrast problems often arise when the foreground color of one object is overlaid onto the (foreground or background) color of another object, resulting in an unintended contrast. It is therefore important for technologies to allow both the foreground and background color of objects to be set to reasonable values and avoid this overlay problem.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Compositing rules for foreground and background colors are well defined. </td>
-					<td>When color compositing rules are not clearly designed, unexpected color contrast can occur. The most frequent problem is when aliasing of edges causes visual artifacts, which in the case of text with its narrow strokes can significantly impact perception. Impacts of borders, shadows, and transparency can also lead to inaccessible contrast. Therefore technologies should specify compositing rules very precisely.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides features to accept user input</th>
-				</tr>
-				<tr>
-					<td>There is a mechanism to label user input controls in an unambiguous and clear manner.</td>
-					<td>When collecting user input, users must know what input is required for each control. Often this is made evident by visual context, but this does not help non-visual users or users of alternate visual presentations such as magnification. When labels are provided, if they are not programmatically associated with the control, users may not be able to find the correct label. Therefore it is important for technologies to provide ways to associate labels with their controls.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can associate extended help information with a control.</td>
-					<td>When authors request user input that may require special assistance, such as details of the input format required or how to find an account number on a bill, they may provide extended help in addition to the label. Even if this is positioned near the control, some users may not reliably find it. Therefore technologies should provide a way for authors to explicitly attach extended help (including links to extended help) directly to the control.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>If there is an input error, it is possible to associate the error message clearly with the specific control that is in error.</td>
-					<td>If a user inputs data that is not accepted by the system, a report of the issue is made and the user given an opportunity to correct the input. Such error messages are frequently provided at the top of the form, from where it can be difficult for the user to locate the control that needs input corrected. Even if the error message is positioned closer to the control, it can be difficult to find the correct control. Therefore, much like labels and help content, technologies need to provide a way to associate error messages directly with the control to which they apply.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>There is a mechanism to report and set the state or value of controls programmatically.</td>
-					<td>While much user input is collected using platform input services, some users use assistive technologies that work better when interacting programmatically with the content directly, effectively in an alternate user interface. For this to work, technologies need to provide a means for assistive technologies to get and set the nature, state, and value of input controls.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can address multiple types of input hardware (keyboard, pointing device, touch screen, voice recognition, etc.), or the technology supports hardware-agnostic input methods. </td>
-					<td>A basic tenet of accessibility is that users should be able to user input and output hardware that is optimal for them. Some use alternate versions of familiar hardware, such as keyboard-compatible and pointing devices, while others use less widespread types of hardware, such as voice recognition, single-switch devices, Braille displays, etc. Technologies should design content input and output methods to be agnostic to the specific hardware used, and provide application programming interfaces for supported hardware types such as keyboard and pointer so other hardware can effectively interact. Technologies should also emphasize the most hardware-neutral form of authoring feasible via more abstract events, and when providing hardware-specific features ensure that multiple types of hardware can be addressed.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>User input does not require specific physical characteristics (e.g., fingerprint readers).</td>
-					<td>Some user input depends on specific physical characteristics of users. For instance, early touch screens required users to have a physical, not a prosthetic, finger, and fingerprint readers also require users to have a fingerprint. Some users do not have the ability to interact with such devices. Technologies should not require specific user characteristics, and should provide alternate ways to accomplish tasks if such features are provided.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can ensure a "meaningful" order of controls exists regardless of presentation. </td>
-					<td>Much like the issue of navigation order deviating from display order mentioned above, control order is another frequent source of confusion for users when presentation has been customized. Technologies should provide ways for authors to define the intended order of user input controls.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides user interaction features</th>
-				</tr>
-				<tr>
-					<td>For every user interface object type, the "type" of object can be exposed as a role to accessibility APIs. </td>
-					<td>A major way some users with disabilities access content is via assistive technologies, which provide various supplemental supports for interaction. Many assistive technologies interact with content primarily via accessibility APIs, which contain an abstract model of the content that includes information about each object. The "type" of an object is important for users to know how to use it, which is typically exposed to accessibility APIs as a "role". Technologies should ensure features have a defined type and, if necessary, document accessibility API mappings for the several APIs in use.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>For every user interface object type, there is a clearly defined mechanism for authors to provide and / or user agents determines the "accessible name" for accessibility APIs. </td>
-					<td>Accessibility APIs provide an "accessible name" for each object, which labels it for the user. The accessible name is frequently the label for a form control or the text alternative for an object. Technologies should define how the accessible name for each object type can be determined, and provide features to allow authors to set the accessible name.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>For user interface objects that can have states, properties, or values, authors can set these and these can be exposed to accessibility APIs. </td>
-					<td>Along with the role, many objects require information about properties, states, and values to be fully usable. Properties are generally specific to object types and refine the type of object; states are also specific to object type and provide information about a changeable condition such as checked status of a checkbox or visibility status of an object. All objects have values as well, which is often the text content but can be from another source, such as the user input in a form control. Technologies should define ways for user agents to expose and authors to set properties, states, and values in accessibility APIs that are relevant to full understanding of and interaction with the object type.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>When providing imperative mechanisms to implement technology features (e.g., scripts), authors can expose accessibility information to accessibility APIs. </td>
-					<td>Declarative technologies provide structured semantic helping authors to define complete models for objects that can be exposed to accessibility APIs. Imperative technologies give more freedom to the author but provide less built-in accessibility semantics, and sometimes do not provide a way to address accessibility APIs at all. Technologies that use imperative mechanisms to author content need to provide full interfaces to accessibility APIs so authors can set the complete object model.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>User can obtain help information about the widget. </td>
-					<td>Especially with novel widgets, users sometimes need context-specific help to learn how to use the widget effectively. This information is only useful if users can easily find it. Therefore, technologies should provide a mechanism for help information to be directly associated with and reachable from the control.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology defines document semantics</th>
-				</tr>
-				<tr>
-					<td>Authors can title Web pages. </td>
-					<td>Web content is classically exposed on "pages", each of which contains a different chunk of content. To help users easily identify their location in a set of pages, and navigate to the correct page, each pages should have a title that is effectively metadata. Technologies should provide ways for authors to create unique titles for each page. </td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can title sections of content. </td>
-					<td>Web content is frequently divided into multiple sections, each of which has a distinct topic. Users navigate among these sections to find the content most relevant to their purpose, which is especially important for users of assistive technology that don't provide a two-dimensional view of the content. Technologies should provide a mechanism for authors to provide section titles to help users navigate and identify their location.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can clearly indicate the target of a hyperlink and function of a control. </td>
-					<td>Hyperlinks and controls cause changes to the user experience. It is important that users know what change will happen, or what the result of navigating a hyperlink will be. Default or contextual indications may be sufficient for some users but not all. Technologies must provide features allowing authors to unambiguously provide this information.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can indicate content language, for the page as a whole and for blocks of content. </td>
-					<td>Assistive technology that process language, such as screen readers, braille displays, and voice input, change according to human language of content. For instance, pronunciation rules and the effect of certain utterances may change. Technologies need to allow authors to indicate the language of content, both as a whole and for regions where it differs.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can support understanding of abbreviations / acronyms / initialisms, idioms, jargon, etc. </td>
-					<td>Abbreviations, acronyms, initialisms, idioms, and jargon comprise usages of content that may not be familiar to all users, so it can be helpful for authors to provide supplemental information about meaning. Abbreviations, acronyms, and initialisms are also often frequently pronounced different from their spelling, their special nature may not be obvious from pronunciation alone. Therefore technologies should allow authors to provide pronunciation and meaning guidance for these language features.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can support correct machine pronunciation of ambiguously spelled terms (e.g., in the phrase "I am content with this content" there are different correct pronunciations of the lexeme "content"). </td>
-					<td>Many languages have lexical features that can be pronounced different ways and that carry different meanings. Context generally clarifies intent, but this can be less effective when assistive technologies use default pronunciations. Therefore technologies should provide features to allow authors to clarify pronunciation intent when needed.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can identify regions of content, particularly the "main" region.</td>
-					<td>Users of some assistive technologies experience content in a linear fashion, which can make it hard to find intended content that is located after several blocks of less relevant content such as navigation and sidebars. Other users have difficulty making sense of the page design due to complexity or the effects of magnification. Supporting users to find relevant content quickly is important to effective use, and the best way to do this is to provide ways to identify regions of content easily. This can be done via headings but region type semantics is also particularly helpful. The main content region is the most important for users to find quickly, but other regions such as navigation, headers, footers, sidebars, and subsections are also important. Technologies should provide features to allow authors to identify content regions.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Declarative mechanisms (that have accessibility semantics pre-defined in the spec) are used to implement technology features whenever possible. </td>
-					<td>Declarative technologies create sets of pre-defined semantics that authors use to structure content. Because the semantics are well-defined, they can be broadly supported across the entire tool chain, including by assistive technologies. Imperative technologies, by contrast, don't define semantics in advance, which allows creation of new forms of content but requires authors to implement all aspects of the user experience, including accessibility aspects that are frequently overlooked. For this reason, technologies should provide declarative semantics for known feature types.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>There are unambiguous ways to express relationships between units of content, such as object nesting, ID referencing, etc. </td>
-					<td>Providing an accessible user experience sometimes requires tools to combine the features of or support rapid navigation between multiple related objects. Technologies should provide ways for authors to define these relationships clearly and unambiguously.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Prefer structural semantics to presentational semantics. </td>
-					<td>Structural semantics provide information about the role of content within the whole, while presentational semantics define intended presentation. Authors frequently use presentation to convey structure, yet when taken out of context this presentation is not meaningful to all users. Technologies should emphasize structural semantics over presentational semantics, and support styling on the basis of structure rather than inferring structure on the basis of style.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>When providing presentational semantics, they can be easily mapped to structural semantics, e.g., to support restyling or meaningful exposure to accessibility APIs. </td>
-					<td>If technologies do provide presentational semantics, they should define clear mappings to existing structural semantics as well, allowing users to interact with content on the basis of implied structure.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Support a comprehensive set of authoring use cases to minimize the need for alternative content. (e.g., don't make authors resort to text in images to get the style they want).</td>
-					<td>Many accessibility problems in web content arise from authors attempting to work around limitations of the content language and using the technology in a way that it was not intended. Technologies should provide rich feature sets that allows authors to accomplish their goals without resort to inaccessible usages.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Semantics allow precise and replicable location information in the document to be determined.</td>
-					<td>Finding a given location in a document is important for a variety of use cases. Users of some assistive technologies require the tool to navigate to the location for them and may be confused if the location is merely approximate. Technologies should enable precise location finding, not only by supporting unique IDs but by structuring the language such that unambiguous and replicable selectors can be used and shared.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Semantics exist to convey meaning that is commonly conveyed via presentation.</td>
-					<td>Meaning is conveyed by a variety of presentational attributes. Separated blocks of text represent paragraphs, indented text represents quotes, short enlarged text indicates headings, bold text conveys emphasis, relative size indicates relative importance, etc. Technologies should define structural semantics for such features.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides time-based visual media (see also the <a href="https://www.w3.org/WAI/PF/HTML/wiki/Media_Accessibility_Checklist">Media Accessibility Checklist</a>)</th>
-				</tr>
-				<tr>
-					<td>It is possible for authors to provide detailed text descriptions, audio descriptions, or both of the important content in the media. </td>
-					<td>Some visual media cannot at present be made directly accessible to some users. Accessibility is provided via text or audio descriptions, either as part of the content or as an easily found supplementary resource. Technologies should provide mechanisms to provide these descriptions and associate them with the media.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>It is possible for authors to synchronize descriptions with the visual content.</td>
-					<td>Descriptions are sometimes more helpful when they can be accessed along with the main video content. Technologies should provide a mechanism to synchronize descriptions, e.g., via additional audio tracks, timed text, etc.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>It is possible for to provide descriptions even when the content is live.</td>
-					<td>It is harder to provide descriptions for live content, because the description must be produced at the same time as the content itself. Nonetheless, for some live content such as newscasts with a broad audience, this can be an important feature. Technologies should provide support for live descriptions.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>User can pause, stop, replay media.</td>
-					<td>While most media can be stopped (where replay restarts from the beginning) or paused (where replay restarts from where it starts), the controls to do so can be inaccessible to users. Technologies need to provide accessible controls to do this, and also support programmatic control so assistive technologies can pause, stop, and start media playback. This support is important even for media that is not generally intended to be used in this way, such as short autoplay clips, in order to provide users control over excessive distraction.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Users can send output to alternate device.</td>
-					<td>Some users use multiple video or audio devices to tune their accessible interaction. For instance, a screen reader user may direct content audio to a different device than screen reader audio in order to reduce collision, or a magnifier user may direct video to a separate screen in order to better arrange their available screen space. Technologies should provide features to support this.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides audio</th>
-				</tr>
-				<tr>
-					<td>It is possible for authors to provide transcriptions. </td>
-					<td>Like descriptions of video, transcriptions of audio is important for some users. Authors should be able to provide text transcripts or signed video alternatives and associate them directly with the primary content.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>It is possible for authors to provide synchronized captions, either open (on by default for all users).</td>
-					<td>Captions are essentially text transcripts that are synchronized to appear in small blocks when the relevant audio is playing. Closed captions are visible only on request, and are best provided in a timed text track although they are sometimes provide in a separate video track. Open captions are included directly within the source video. Technologies should provide features to allow authors to create closed and open captions.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>User can adjust volume level </td>
-					<td>Some users require different volume levels than default, and may need the relative volume of different elements to be different. Technologies should provide ways for users to adjust the volume of audio content within the content, not simply relying on hardware volume settings.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Contrast between foreground and background audio is sufficient </td>
-					<td>Understanding of audio is improved when background sounds do not occlude foreground or primary audio. To support this, authors should be able to set background and foreground levels separately. Ideally, users should also be able to adjust them separately via separate audio tracks.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Unnecessary background audio can be muted separately from the foreground audio </td>
-					<td>When background audio makes understanding of content too difficult, users should be able to suppress it without losing the foreground audio. Technologies should provide features to make this possible, e.g., via support of multiple audio tracks.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Technology does not include triggers for audiosensitive seizures or allows those triggers to be disabled.</td>
-					<td>Like photosensitive epilepsy, audiosensitive epilepsy is known to occur. The triggering conditions are less widely known at this time, but nonetheless technologies should avoid enabling authoring of triggering content, or provide means to detect, warn, avoid, and suppress triggering content.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology allows time limits</th>
-				</tr>
-				<tr>
-					<td>A feature exists to allow time limits to be extended. </td>
-					<td>Because of the additional time cost to using assistive technologies, or because of difficulty processing content, some users need more time to accomplish tasks than average. Common time limits can be time for response before a login session expires, or time before content automatically refreshes or changes. When technologies allow authors to set time limits, they should provide ways for users to request extensions to the time limit - before the expiration of the limit causes a disastrous interruption to their use. Some content does require a time limit, such as financial transactions or testing, so technologies should also allow authors or test proctors to define limits for how much extension users should be able to obtain.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Time limits for different parts of a task, such as reading instructions vs providing input, can be set separately. </td>
-					<td>Different activities require different amounts of time for different users. Technologies should allow authors to set time limits in a fine-grained manner when needed.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology allows text content</th>
-				</tr>
-				<tr>
-					<td>Authors can define non-text alternatives for text content. </td>
-					<td>While text is the universal accessible alternative, it is still not the best format for some users. Technologies should allow authors to provide non-text alternatives to text content when needed. Various types of alternatives are useful in different situations, including visual such as icons or movies, auditory such as pronunciation cues and recorded speech, and haptic.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can define non-text alternatives for non-text content. </td>
-					<td>Even though text alternatives for non-text content is generally recommended, in some situations a non-text alternative is more suitable. For instance, a haptic version of a map, in which features are conveyed by touch features, can be easier to understand than a text alternative. Technologies should allow authors to provide these enhance alternatives in addition to text alternatives.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology creates objects that don't have an inherent text representation</th>
-				</tr>
-				<!--
-<tr>
-<td colspan="3">This includes primarily images, video, and audio but can also include other forms of complex content. Objects should also be directly accesible, but text alternatives are needed as a universal fallback.</td>
-</tr>
--->
-				<tr>
-					<td>There is a mechanism to create short text alternatives that label the object. </td>
-					<td>Some non-text objects can be represented as text, such as form controls, user interface objects, etc. Authors have no inherent text version that can be meaningfully exposed to the user. In this case, technologies should allow authors to provide a short label for the object.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>There is a mechanism to create extended text alternatives for fallback content.</td>
-					<td>In addition to labels, authors should be able to provide extended text alternatives to better describe non-text objects. Technologies should provide a feature for this extended description that is distinct from the short label, and that can be associated with the object.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Text alternatives can be semantically "rich" e.g., with page structure, text style, hyperlinks, etc. </td>
-					<td>Extended text alternatives should allow authors to use, and users to benefit from, full text semantics rather than reduce them to plain text.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides content fallback mechanisms, whether text or other formats</th>
-				</tr>
-				<tr>
-					<td>Authors can explicitly mark content as not needing alternative content because it does not perform an important role. </td>
-					<td>Some non-text content does not require an alternative version because it does not perform a function important to understanding the overall content, such as objects to facilitate layout, add graphical interest, etc. In order to avoiding requiring users to determine their role, technologies should provide a mechanism for authors to state explicitly that the object does not require an alternate version</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Content can explicitly indicate when author declined to provide alternative content. </td>
-					<td>Sometimes authoring tools prompt authors to provide alternative content, but they do not do so. Technologies should provide a feature to allow the user to be notified that the author chose not to provide alternative content.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Content can explicitly indicate that authoring tool is unable to generate or obtain alternative content. </td>
-					<td>Some authoring tools attempt to generate alternate content, but are not always able to. Technologies should allow tools to indicate to users that they were not able to generate alternate content.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can explicitly associate alternative content with the primary content. </td>
-					<td>Technologies should enable authors to associate alternative content unambiguously with the main content.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Authors can associate multiple types and instances of alternative content with primary content. </td>
-					<td>Sometimes, it is appropriate for authors to provide multiple forms of alternate content. Technologies should allow more than one unit of alternate content to be associated with a given object.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>Alternate content can be easily found from the initial content. </td>
-					<td>Replaces, referenced directly from, at same location of initial content.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides visual graphics</th>
-				</tr>
-				<tr>
-					<td>Item </td>
-					<td>This is a developing area, being explored by the <a href="https://www.w3.org/WAI/PF/svg-a11y-tf/">SVG Accessibility Task Force</a>.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides internationalization support</th>
-				</tr>
-				<tr>
-					<td>Accessibility features can be internationalized to the same degree as other features </td>
-					<td>Technologies that support internationalization must not overlook accessibility features. In particular for content alternatives, technologies should support including multiple language alternatives, language identification and changes within alternative content, text directionality identification, etc.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology defines accessible alternative features</th>
-				</tr>
-				<tr>
-					<td>Accessible alternatives themselves meet the same bar of accessibility. </td>
-					<td>For instance, captions should be able to have color and style changed by the user. Text alternatives should allow rich content. Audio descriptions should be separable from other sound.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology provides content directly for end-users</th>
-				</tr>
-				<tr>
-					<td>Content can be encoded in a manner that allows machine transformation into accessible output </td>
-					<td>Some technologies encode content into a binary format that requires specific software to execute and render the content. Unless that format provide robust interaction with accessibility APIs and comprehensive transformation support, this will reduce the scope of accessible transformation that could be possible for the content. Technologies should choose content formats that allow easy transformation including from third-party tools and services.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology defines an API</th>
-				</tr>
-				<tr>
-					<td>If the API can be used for structured content, it provides features to represent all aspects of the content including hidden accessibility features. </td>
-					<td>Application programming interfaces allow programmatic manipulation and interchange of content, and are being used to create a more imperative Web. While typically APIs exchange data rather than user-focused content, this data ultimately is exposed to the user in some way. Some of the content richness can disappear if the API does not support features like content alternatives, control association, etc. Technologies that define APIs should ensure the API is rich enough to exchange all relevant accessibility information.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>If the API relies on user agents to generate a user interface, the specification provides guidance about accessibility requirements needed to enable full interaction with the API. </td>
-					<td>Content manipulated by an API is generally generated into a user interface. Technologies should provide guidance to ensure that user agents or dynamic content applications expose the full set of accessibility information available in the API.</td>
-					<td></td>
-				</tr>
-			</tbody>
-			<tbody>
-				<tr>
-					<th colspan="3" scope="rowgroup">If technology defines a transmission protocol</th>
-				</tr>
-				<tr>
-					<td>Use of the protocol does not cause any aspect of the content, including metadata which could contain important accessibility information, to be removed. </td>
-					<td>Transmission protocols exchange content between devices. Sometimes protocols remove content viewed as unimportant, or restrict what can be transmitted for security or provenance reasons. This can have unintended impacts on accessibility features in the content. Technologies defining transmission profiles need to ensure all aspects of the content relevant to accessibility are included.</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>It is possible to use third-party accessibility enhancement services while using the protocol. </td>
-					<td>On the Web, content is typically exchanged between a client and server. For accessibility, some third-party tools may act between these endpoints to modify the content to a form that is more suitable for the user. While transmission protocols need to avoid unintended modification of the stream, they also need to provide support for this use case.</td>
-					<td></td>
-				</tr>
-			</tbody>
-		</table>
-	</body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <title>FAST Checklist</title>
+    <link rel="stylesheet" href="checklist.css" />
+  </head>
+
+  <body>
+    <main>
+        <h1>[DRAFT] <abbr title="Framework for Accessible Specification of Technologies">FAST</abbr> Checklist</h1>
+      <p>
+      This is a draft checklist to support <a href="https://raw.githack.com/w3c/fast/checklist-W3C-format/index.html">Framework for Accessible Specification of Technologies (FAST)</a> prepared by the <a href="https://www.w3.org/WAI/about/groups/apawg/">Accessible Platform Architectures Working Group</a>. The goal of <abbr title="Framework for Accessible Specification of Technologies">FAST</abbr> is to describe the features that web technologies should provide to ensure it is possible to create content that is accessible to users with disabilities. The full framework references an analysis of user requirements, describes how technologies, content authoring, and user agents work together to meet these needs, and provides comprehensive guidance to technology developers. This checklist extracts that information at a high level to aid in self-review of technologies. Specification developers can use this to help ensure the technology will address features likely to be raised during horizontal review from accessibility proponents.
+    </p>
+
+    <p>Web technologies address a variety of needs, and play a variety of roles in web accessibility. Content languages describe primary content, styling languages impact presentation, APIs enable manipulation and data interchange, and protocols tie it all together. Each of these types of technologies can impact accessibility.</p>
+
+    <p>This checklist is organized by types of features that a technology may provide. If the technology provides such a feature, the checklist items under the heading are applicable and should be examined. If the technology does not provide such a feature, the checklist items under the heading are not applicable and can be passed over.</p>
+     <fieldset>
+        <legend>Document or spec being reviewed</legend>
+        <div class="grid-2c">
+          <label for="spec-name">Name:</label>
+          <input id="spec-name" type="text" name="spec-name" required />
+          <label for="spec-url">URL:</label>
+          <input id="spec-url" type="text" name="spec-url" aria-describedby="spec-url-desc" required />
+        </div>
+        <div id="spec-url-desc">
+          <p>Please ensure this dated, or for a specific commit, for example:</p>
+          <ul>
+            <li>
+              <p><a
+                  href="https://www.w3.org/TR/2025/CRD-compute-pressure-20250521">https://www.w3.org/TR/2025/CRD-compute-pressure-20250521</a>
+              </p>
+            </li>
+            <li>
+              <p><a
+                  href="https://github.com/guidou/webrtc-encoded-transform/blob/d9648352c57804b3bc805a3c649b3f2624025a7b/timestamps.md">https://github.com/guidou/webrtc-encoded-transform/blob/d9648352c57804b3bc805a3c649b3f2624025a7b/timestamps.md</a>
+              </p>
+            </li>
+          </ul>
+        </div>
+      </fieldset>
+
+        <fieldset>
+        <legend>GitHub repository of the document or spec being reviewed</legend>
+        <div class="grid-2c">
+          <label for="spec-repo">URL:</label>
+          <input id="spec-repo" type="text" name="spec-repo" aria-describedby="spec-repo-format" />
+        </div>
+            <p id="spec-repo-format"><b>Format: </b>https://github.com/org/repo</p>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology allows visual rendering of content
+         </legend>
+        
+        <input type="radio" id="q1_yes" name="q1" value="Yes" required aria-describedby="q1Description" checked />
+        <label for="q1_yes">Yes</label>
+        <input type="radio" id="q1_no" name="q1" value="No" required aria-describedby="q1Description" />
+        <label for="q1_no">No</label>
+
+        <details>
+            <summary>
+                Visual rendering checklist
+            </summary>
+
+            <table
+            role="table"
+            aria-label="If technology allows visual rendering of content checklist"
+            id="table1"
+            >
+            <thead>
+                <tr>
+                <th scope="col">Checkpoint</th>
+                <th scope="col">References</th>
+                <th scope="col">Met?</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                <th scope="row" aria-labelledby="s1">
+                    <details open>
+                    <summary id="s1">
+                    There is a defined way for a non-visual rendering to be created.
+                    </summary>
+                    <p>
+                        Content is frequently authored with visual rendering the primary
+                        consideration. Some users are not able to access visual content,
+                        and must use other forms of the content, such as text or audio.
+                    </p>
+                    </details>
+                </th>
+                <td> <a
+                        href="https://www.w3.org/WAI/WCAG20/quickref/#non-text-content"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >WCAG 2.0 Quick Reference</a
+                    ></td>
+                   
+                </td>
+                <td class="met-column">
+                    <label><input type="radio" id="met1" name="met1" value="yes"> Yes</label>
+                    <label><input type="radio" id="met1" name="met1" value="no"> No</label>
+                </td>
+                </tr>
+
+                <tr>
+                <th scope="row" aria-labelledby="s2">
+                    <details open>
+                    <summary id="s2">
+                    Content can be resized.
+                    </summary>
+                    <p>
+                    Many users need content to be displayed larger than the default,
+                    not just because of un-sharp vision but also to mitigate other
+                    visual perception difficulties such as difficulty separating
+                    foreground from background.
+                    </p>
+                    </details>
+                </th>
+                <td> 
+                    <a
+                        href="https://www.w3.org/WAI/WCAG20/quickref/#resize-text"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >WCAG 2.0 Quick Reference</a
+                    ></td>
+                <td class="met-column">
+                    <label><input type="radio" id="met2" name="met2" value="yes"> Yes</label>
+                    <label><input type="radio" id="met2" name="met2" value="no"> No</label>
+                </td>
+                </tr>
+                <tr>
+                <th scope="row" aria-labelledby="s3">
+                    <details open>
+                    <summary id="s3">
+                    Luminosity and hue contrast can adapt to user requirements.
+                    </summary>
+                    <p>
+                        Users with color vision deficits and other visual impairments have
+                        more difficulty separating certain foreground from background
+                        colors than average.
+                    </p>
+                    </details>
+                </th>
+                <td> 
+                <a
+                    href="https://www.w3.org/WAI/WCAG20/quickref/#contrast-minimum"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >WCAG 2.0 Quick Reference</a
+                    >
+                <td class="met-column">
+                    <label><input type="radio" id="met3" name="met3" value="yes"> Yes</label>
+                    <label><input type="radio" id="met3" name="met3" value="no"> No</label>
+                </td>
+                </tr>
+                <tr>
+                <th scope="row" aria-labelledby="s4">
+                    <details open>
+                    <summary id="s4">
+                    Text presentation attributes can be changed.
+                    </summary>
+                    <p>
+                        Some users with visual impairments and learning disabilities find
+                        that customizing text presentation improves their ability to
+                        distinguish letters, track lines, etc. Technologies should provide
+                        features allowing users to customize typeface, font weight, font
+                        style, line / word / letter spacing, margins, line length,
+                        justification.
+                    </p>
+                    </details>
+                </th>
+                <td></td>
+                
+                <td class="met-column">
+                    <label><input type="radio" id="met4" name="met4"  value="yes"> Yes</label>
+                    <label><input type="radio" id="met4" name="met4" value="no"> No</label>
+                </td>
+                </tr>
+                <tr>
+                <th scope="row" aria-labelledby="s5">
+                    <details open>
+                    <summary id="s5">
+                    Visual presentation of pointers and cursors can be adjusted.
+                    </summary>
+                    <p>
+                        Sometimes pointer and cursor indicators are difficult for users to
+                        distinguish and locate, and incessant animation, even simple
+                        blinking, can be excessively distracting for some users.
+                        Technologies that define pointer and cursor indicators should
+                        provide features for user to customize size, color, and animation.
+                    </p>
+                    </details>
+                </th>
+                <td> </td>
+                
+                <td class="met-column">
+                    <label><input type="radio" id="met5" name="met5" value="yes"> Yes</label>
+                    <label><input type="radio" id="met5" name="met5" value="no"> No</label>
+                </td>
+                </tr>
+                <tr>
+                <th scope="row" aria-labelledby="s6">
+                    <details open>
+                    <summary id="s6">
+                    Changing content presentation does not render it unreadable.
+                    </summary>
+                    <p>
+                        Many accessibility requirements come down to allowing users to
+                        customize presentation. When presentation is changed in a way the
+                        author or designer did not anticipate, unexpected side effects
+                        often appear that create new problems. A frequent situation is
+                        when content is resized but the region for the content is not,
+                        causing the content to be clipped. Another is when regions resize
+                        but do not reposition, making it difficult to use the content at
+                        the new scale. Change of font attributes sometimes leads to a
+                        similar problem, such as when users change to a heavier font but
+                        the space allocated for characters does not increase. Technologies
+                        should provide features to ensure that change of display
+                        attributes does not create unintended side effects.
+                    </p>
+                    </details>
+                </th>
+                <td> </td>
+                
+                <td class="met-column">
+                    <label><input type="radio" id="met6" name="met6" value="yes"> Yes</label>
+                    <label><input type="radio" id="met6" name="met6"  value="no"> No</label>
+                </td>
+                </tr>
+                <tr>
+                <th scope="row" aria-labelledby="s7">
+                    <details open>
+                    <summary id="s7">
+                        Technology does not allow blinking or flashing of content, or
+                        provides a feature for users to quickly turn it off or
+                        permanently disable it.
+                    </summary>
+                    <p>
+                        Technologies should not provide features that allow authors to
+                    create content that
+                    <a
+                        href="https://www.w3.org/TR/WCAG20/#blinksdef"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >blinks</a
+                    >
+                    (which can be excessively distracting) or
+                    <a
+                        href="https://www.w3.org/TR/WCAG20/#flash-def"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >flashes</a
+                    >
+                    (which can be medically disastrous). However, technologies that
+                    provide general animation features (even simple ones) may be
+                    unable to rule out author usages that create these effects. It is
+                    important for such technologies to provide a feature for users to
+                    stop animation, or prevent it until requested. More complex
+                    technologies should also provide means to mark potentially
+                    problematic content, warn users who have opted into the warning,
+                    and give users the option to skip or suppress problematic regions
+                    of content.
+                    </p>
+                    </details>
+                </th>
+                <td> </td>
+                
+                <td class="met-column">
+                    <label><input type="radio" id="met7" name="met7"  value="yes"> Yes</label>
+                    <label><input type="radio" id="met7" name="met7"  value="no"> No</label>
+                </td>
+                </tr>
+                <tr>
+                <th scope="row" aria-labelledby="s8">
+                    <details open>
+                    <summary id="s8">
+                        It is possible to make navigation order correspond to the visual
+                        presentation.
+                    </summary>
+                    <p>
+                        Flexible display mechanisms can cause content to appear in
+                        unpredicted locations. This is often a good feature as it allows
+                        optimization of display. However, the navigation order of such
+                        content sometimes does not match the perceived order, and users
+                        have difficulty using linear (i.e., keyboard-based) navigation
+                        effectively. Technologies should provide features to ensure when
+                        the visual order of content changes, the interaction order changes
+                        to match.
+                    </p>
+                    </details>
+                </th>
+                <td> </td>
+                
+                <td class="met-column">
+                    <label><input type="radio" id="met8" name="met8" value="yes"> Yes</label>
+                    <label><input type="radio" id="met8" name="met8" value="no"> No</label>
+                </td>
+                </tr>
+            </tbody>
+            </table>
+        </details>
+
+        
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology provides author control over color
+        </legend>
+        
+        <input type="radio" id="q2_yes" name="q2" value="Yes" required aria-describedby="q2Description" checked />
+        <label for="q2_yes">Yes</label>
+        <input type="radio" id="q2_no" name="q2" value="No" required aria-describedby="q2Description" />
+        <label for="q2_no">No</label>
+
+        <details>
+            <summary>
+                 Author control checklist
+            </summary>
+
+                <table
+                role="table"
+                aria-label="If technology provides author control over color checklist"
+                id="table2"
+                >
+                    <thead>
+                        <tr>
+                        <th scope="col">Checkpoint</th>
+                        <th scope="col">References</th>
+                        <th scope="col">Met?</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                        <th scope="row" aria-labelledby="s9">
+                            <details open>
+                            <summary id="s9">
+                            There is a mechanism for users to override colors of text and
+                            user interface components.
+                            </summary>
+                            <p>
+                            Custom color settings benefits not only users with visual
+                            perception impairments, but also users who can be distracted by
+                            certain colors or combinations. Technologies should provide
+                            features to allow users to set their own colors or contrast for
+                            text (including background) and standard user interface
+                            components.
+                            </p>
+                            </details>
+                        </th>
+                        <td></td>
+                        <td class="met-column">
+                            <label><input type="radio" id="met9" name="met9" value="yes"> Yes</label>
+                            <label><input type="radio" id="met9" name="met9" value="no"> No</label>
+                        </td>
+                        </tr>
+
+                        <tr>
+                        <th scope="row" aria-labelledby="s10">
+                            <details open>
+                            <summary id="s10">
+                            There is a feature for authors to define semantically available
+                            "color classes" that users can easily map to custom colors, and
+                            give preference to this vs. coloring objects individually.
+                            </summary>
+                            <p>
+                            Allowing user override of author design is most effective when the
+                            technology provides rich semantics for content, on which author or
+                            default colors are based, that can be easily recolored in a
+                            meaningful manner. Technologies should define semantics, or a way
+                            for authors to define and communicate the semantics they use, to
+                            allow most effective recoloring with minimal advance knowledge of
+                            site implementation.
+                            </p>
+                            </details>
+                        </th>
+                        <td></td>
+                        <td class="met-column">
+                            <label><input type="radio" id="met10" name="met10"  value="yes"> Yes</label>
+                            <label><input type="radio" id="met10" name="met10" value="no"> No</label>
+                        </td>
+                        </tr>
+                        <tr>
+                        <th scope="row" aria-labelledby="s11">
+                            <details open>
+                            <summary id="s11">
+                            There is a feature for users to choose color schemata that work
+                            for them.
+                            </summary>
+                            <p>
+                            Content authors are frequently concerned with branding, and want
+                            to ensure that the color scheme of content communicates the brand.
+                            But when the color scheme makes content inaccessible to users this
+                            goal can be counter-productive. Technologies can increase author
+                            control and user accessibility by providing a way for authors to
+                            define multiple color schemes, allowing more accessible schemes
+                            still to partake in the branding process, and allowing users to
+                            choose from among available schemes.
+                            </p>
+                            </details>
+                        </th>
+                        <td></td>
+                        <td class="met-column">
+                            <label><input type="radio" id="met11" name="met11" value="yes"> Yes</label>
+                            <label><input type="radio" id="met11" name="met11" value="no"> No</label>
+                        </td>
+                        </tr>
+                        <tr>
+                        <th scope="row" aria-labelledby="s12">
+                            <details open>
+                            <summary id="s12">
+                            The foreground and background color of an object can be reported
+                            to the user via AT.
+                            </summary>
+                            <p>
+                            Experienced color of content is frequently the way users refer to
+                            it; for instance in "redlined" text people may say "find my edits
+                            in red". Users of assistive technologies who cannot perceive the
+                            color directly therefore still have a need to know the color in
+                            order to interact with others. Therefore, technologies should
+                            define a way for foreground and background color to be reported to
+                            assistive technologies and easily searched.
+                            </p>
+                            </details>
+                        </th>
+                        <td> </td>
+                        
+                        <td class="met-column">
+                            <label><input type="radio" id="met12" name="met12" value="yes"> Yes</label>
+                            <label><input type="radio" id="met12" name="met12" value="no"> No</label>
+                        </td>
+                        </tr>
+                        <tr>
+                        <th scope="row" aria-labelledby="s13">
+                            <details open>
+                            <summary id="s13">
+                            There are ways to set foreground and background colors
+                            separately for all objects.
+                            </summary>
+                            <p>
+                            Color contrast problems often arise when the foreground color of
+                            one object is overlaid onto the (foreground or background) color
+                            of another object, resulting in an unintended contrast. It is
+                            therefore important for technologies to allow both the foreground
+                            and background color of objects to be set to reasonable values and
+                            avoid this overlay problem.
+                            </p>
+                            </details>
+                        </th>
+                        <td> </td>
+                        
+                        <td class="met-column">
+                            <label><input type="radio" id="met13" name="met13" value="yes"> Yes</label>
+                            <label><input type="radio" id="met13" name="met13" value="no"> No</label>
+                        </td>
+                        </tr>
+                        <tr>
+                        <th scope="row" aria-labelledby="s14">
+                            <details open>
+                            <summary id="s14">
+                                Compositing rules for foreground and background colors are well
+                                defined.
+                            </summary>
+                            <p>
+                            When color compositing rules are not clearly designed, unexpected
+                            color contrast can occur. The most frequent problem is when
+                            aliasing of edges causes visual artifacts, which in the case of
+                            text with its narrow strokes can significantly impact perception.
+                            Impacts of borders, shadows, and transparency can also lead to
+                            inaccessible contrast. Therefore technologies should specify
+                            compositing rules very precisely.
+                            </p>
+                            </details>
+                        </th>
+                        <td> </td>
+                        
+                        <td class="met-column">
+                            <label><input type="radio"  id="met14" name="met14" value="yes"> Yes</label>
+                            <label><input type="radio"  id="met14" name="met14" value="no"> No</label>
+                        </td>
+                        </tr>
+                    </tbody>
+                </table>
+  </details>
+
+        
+      </fieldset>
+
+       <fieldset>
+         <legend>
+          If technology provides features to accept user input
+        </legend>
+        
+         <input type="radio" id="q3_yes" name="q3" value="Yes" required aria-describedby="q3Description" checked />
+         <label for="q3_yes">Yes</label>
+         <input type="radio" id="q3_no" name="q3" value="No" required aria-describedby="q3Description" />
+         <label for="q3_no">No</label>
+
+        <details>
+            <summary>
+            User input checklist
+            </summary>
+
+                <table
+                role="table"
+                aria-label="If technology provides features to accept user input checklist"
+                id="table3"
+                >
+                <thead>
+                    <tr>
+                    <th scope="col">Checkpoint</th>
+                    <th scope="col">References</th>
+                    <th scope="col">Met?</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                    <th scope="row" aria-labelledby="s15">
+                        <details open>
+                        <summary id="s15">
+                        There is a mechanism to label user input controls in an
+                        unambiguous and clear manner.
+                        </summary>
+                        <p>
+                        When collecting user input, users must know what input is required
+                        for each control. Often this is made evident by visual context,
+                        but this does not help non-visual users or users of alternate
+                        visual presentations such as magnification. When labels are
+                        provided, if they are not programmatically associated with the
+                        control, users may not be able to find the correct label.
+                        Therefore it is important for technologies to provide ways to
+                        associate labels with their controls.
+                        </p>
+                        </details>
+                    </th>
+                    <td></td>
+                    <td class="met-column">
+                        <label><input type="radio" id="met15" name="met15" value="yes"> Yes</label>
+                        <label><input type="radio" id="met15" name="met15" value="no"> No</label>
+                    </td>
+                    </tr>
+
+                    <tr>
+                    <th scope="row" aria-labelledby="s16">
+                        <details open>
+                        <summary id="s16">
+                        Authors can associate extended help information with a control.
+                        </summary>
+                        <p>
+                        When authors request user input that may require special
+                        assistance, such as details of the input format required or how to
+                        find an account number on a bill, they may provide extended help
+                        in addition to the label. Even if this is positioned near the
+                        control, some users may not reliably find it. Therefore
+                        technologies should provide a way for authors to explicitly attach
+                        extended help (including links to extended help) directly to the
+                        control.
+                        </p>
+                        </details>
+                    </th>
+                    <td></td>
+                    <td class="met-column">
+                        <label><input type="radio" id="met16" name="met16" value="yes"> Yes</label>
+                        <label><input type="radio" id="met16" name="met16" value="no"> No</label>
+                    </td>
+                    </tr>
+                    <tr>
+                    <th scope="row" aria-labelledby="s17">
+                        <details open>
+                        <summary id="s17">
+                        If there is an input error, it is possible to associate the
+                        error message clearly with the specific control that is in
+                        error.
+                        </summary>
+                        <p>
+                        If a user inputs data that is not accepted by the system, a report
+                        of the issue is made and the user given an opportunity to correct
+                        the input. Such error messages are frequently provided at the top
+                        of the form, from where it can be difficult for the user to locate
+                        the control that needs input corrected. Even if the error message
+                        is positioned closer to the control, it can be difficult to find
+                        the correct control. Therefore, much like labels and help content,
+                        technologies need to provide a way to associate error messages
+                        directly with the control to which they apply.
+                        </p>
+                        </details>
+                    </th>
+                    <td></td>
+                    <td class="met-column">
+                        <label><input type="radio" id="met17" name="met17" value="yes"> Yes</label>
+                        <label><input type="radio" id="met17" name="met17" value="no"> No</label>
+                    </td>
+                    </tr>
+                    <tr>
+                    <th scope="row" aria-labelledby="s18">
+                        <details open>
+                        <summary id="s18">
+                        There is a mechanism to report and set the state or value of
+                        controls programmatically.
+                        </summary>
+                        <p>
+                        While much user input is collected using platform input services,
+                        some users use assistive technologies that work better when
+                        interacting programmatically with the content directly,
+                        effectively in an alternate user interface. For this to work,
+                        technologies need to provide a means for assistive technologies to
+                        get and set the nature, state, and value of input controls.
+                        </p>
+                        </details>
+                    </th>
+                    <td> </td>
+                    
+                    <td class="met-column">
+                        <label><input type="radio" id="met18" name="met18" value="yes"> Yes</label>
+                        <label><input type="radio" id="met18" name="met18" value="no"> No</label>
+                    </td>
+                    </tr>
+                    <tr>
+                    <th scope="row" aria-labelledby="s19">
+                        <details open>
+                        <summary id="s19">
+                        Authors can address multiple types of input hardware (keyboard,
+                        pointing device, touch screen, voice recognition, etc.), or the
+                        technology supports hardware-agnostic input methods.
+                        </summary>
+                        <p>
+                        A basic tenet of accessibility is that users should be able to
+                        user input and output hardware that is optimal for them. Some use
+                        alternate versions of familiar hardware, such as
+                        keyboard-compatible and pointing devices, while others use less
+                        widespread types of hardware, such as voice recognition,
+                        single-switch devices, Braille displays, etc. Technologies should
+                        design content input and output methods to be agnostic to the
+                        specific hardware used, and provide application programming
+                        interfaces for supported hardware types such as keyboard and
+                        pointer so other hardware can effectively interact. Technologies
+                        should also emphasize the most hardware-neutral form of authoring
+                        feasible via more abstract events, and when providing
+                        hardware-specific features ensure that multiple types of hardware
+                        can be addressed.
+                        </p>
+                        </details>
+                    </th>
+                    <td> </td>
+                    
+                    <td class="met-column">
+                        <label><input type="radio" id="met19" name="met19" value="yes"> Yes</label>
+                        <label><input type="radio" id="met19" name="met19" value="no"> No</label>
+                    </td>
+                    </tr>
+                    <tr>
+                    <th scope="row" aria-labelledby="s20">
+                        <details open>
+                        <summary id="s20">
+                            User input does not require specific physical characteristics
+                            (e.g., fingerprint readers).
+                        </summary>
+                        <p>
+                        Some user input depends on specific physical characteristics of
+                        users. For instance, early touch screens required users to have a
+                        physical, not a prosthetic, finger, and fingerprint readers also
+                        require users to have a fingerprint. Some users do not have the
+                        ability to interact with such devices. Technologies should not
+                        require specific user characteristics, and should provide
+                        alternate ways to accomplish tasks if such features are provided.
+                        </p>
+                        </details>
+                    </th>
+                    <td> </td>
+                    
+                    <td class="met-column">
+                        <label><input type="radio" id="met20" name="met20" value="yes"> Yes</label>
+                        <label><input type="radio" id="met20" name="met20" value="no"> No</label>
+                    </td>
+                    </tr>
+                    <tr>
+                    <th scope="row" aria-labelledby="s21">
+                        <details open>
+                        <summary id="s21">
+                            Authors can ensure a "meaningful" order of controls exists
+                            regardless of presentation.
+                        </summary>
+                        <p>
+                        Much like the issue of navigation order deviating from display
+                        order mentioned above, control order is another frequent source of
+                        confusion for users when presentation has been customized.
+                        Technologies should provide ways for authors to define the
+                        intended order of user input controls.
+                        </p>
+                        </details>
+                    </th>
+                    <td> </td>
+                    
+                    <td class="met-column">
+                        <label><input type="radio" id="met21" name="met21" value="yes"> Yes</label>
+                        <label><input type="radio" id="met21" name="met21" value="no"> No</label>
+                    </td>
+                    </tr>
+                </tbody>
+                </table>
+  </details>
+
+        
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology provides user interaction features
+        </legend>
+        
+         <input type="radio" id="q4_yes" name="q4" value="Yes" required aria-describedby="q4Description" checked />
+         <label for="q4_yes">Yes</label>
+         <input type="radio" id="q4_no" name="q4" value="No" required aria-describedby="q4Description" />
+         <label for="q4_no">No</label>
+
+        <details>
+            <summary>
+                User interaction features checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides user interaction features checklist"
+      id="table4"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s22">
+            <details open>
+              <summary id="s22">
+               For every user interface object type, the "type" of object can
+               be exposed as a role to accessibility APIs.
+              </summary>
+              <p>
+              A major way some users with disabilities access content is via
+              assistive technologies, which provide various supplemental
+              supports for interaction. Many assistive technologies interact
+              with content primarily via accessibility APIs, which contain an
+              abstract model of the content that includes information about each
+              object. The "type" of an object is important for users to know how
+              to use it, which is typically exposed to accessibility APIs as a
+              "role". Technologies should ensure features have a defined type
+              and, if necessary, document accessibility API mappings for the
+              several APIs in use.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met22" name="met22"  value="yes"> Yes</label>
+            <label><input type="radio" id="met22" name="met22"  value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s23">
+            <details open>
+              <summary id="s23">
+              For every user interface object type, there is a clearly defined
+              mechanism for authors to provide and / or user agents determine
+              the "accessible name" for accessibility APIs.
+              </summary>
+              <p>
+              Accessibility APIs provide an "accessible name" for each object,
+              which labels it for the user. The accessible name is frequently
+              the label for a form control or the text alternative for an
+              object. Technologies should define how the accessible name for
+              each object type can be determined, and provide features to allow
+              authors to set the accessible name.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met23" name="met23"  value="yes"> Yes</label>
+            <label><input type="radio" id="met23" name="met23"  value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s24">
+            <details open>
+              <summary id="s24">
+              For user interface objects that can have states, properties, or values, 
+              authors can set these and these can be exposed to accessibility APIs.
+              </summary>
+              <p>
+              Along with the role, many objects require information about properties, states, and values to be fully usable. 
+              Properties are generally specific to object types and refine the type of object; states are also specific to 
+              object type and provide information about a changeable condition such as checked status of a checkbox 
+              or visibility status of an object. All objects have values as well, which is often the text content but 
+              can be from another source, such as the user input in a form control. Technologies should define ways 
+              for user agents to expose and authors to set properties, states, and values in accessibility 
+              APIs that are relevant to full understanding of and interaction with the object type.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met24" name="met24" value="yes"> Yes</label>
+            <label><input type="radio" id="met24" name="met24" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s25">
+            <details open>
+              <summary id="s25">
+              When providing imperative mechanisms to implement technology features (e.g., scripts), 
+              authors can expose accessibility information to accessibility APIs.
+              </summary>
+              <p>
+             Declarative technologies provide structured semantic helping authors to define complete models for 
+             objects that can be exposed to accessibility APIs. Imperative technologies give more freedom to the 
+             author but provide less built-in accessibility semantics, and sometimes do not provide a way to address 
+             accessibility APIs at all. Technologies that use imperative mechanisms to author content need to provide 
+             full interfaces to accessibility APIs so authors can set the complete object model.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met25" name="met25" value="yes"> Yes</label>
+            <label><input type="radio" id="met25" name="met25" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s26">
+            <details open>
+              <summary id="s26">
+                User can obtain help information about the widget.
+              </summary>
+              <p>
+              Especially with novel widgets, users sometimes need context-specific help to learn how to use the widget effectively. 
+              This information is only useful if users can easily find it. Therefore, technologies should provide a mechanism for 
+              help information to be directly associated with and reachable from the control.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met26" name="met26" value="yes"> Yes</label>
+            <label><input type="radio" id="met26" name="met26" value="no"> No</label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology defines document semantics
+        </legend>
+        
+         <input type="radio" id="q5_yes" name="q5" value="Yes" required aria-describedby="q5Description" checked />
+         <label for="q5_yes">Yes</label>
+         <input type="radio" id="q5_no" name="q5" value="No" required aria-describedby="q5Description" />
+         <label for="q5_no">No</label>
+
+        <details>
+            <summary>
+                Document semantics checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology defines document semantics checklist"
+      id="table5"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s27">
+            <details open>
+              <summary  id="s27">
+              Authors can title Web pages.
+              </summary>
+              <p>
+              Web content is classically exposed on "pages", each of which
+              contains a different chunk of content. To help users easily
+              identify their location in a set of pages, and navigate to the
+              correct page, each pages should have a title that is effectively
+              metadata. Technologies should provide ways for authors to create
+              unique titles for each page.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met27" name="met27" value="yes"> Yes</label>
+            <label><input type="radio" id="met27" name="met27" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s28">
+            <details open>
+              <summary  id="s28">
+              Authors can title sections of content.
+              </summary>
+              <p>
+              Web content is frequently divided into multiple sections, each of
+              which has a distinct topic. Users navigate among these sections to
+              find the content most relevant to their purpose, which is
+              especially important for users of assistive technology that don't
+              provide a two-dimensional view of the content. Technologies should
+              provide a mechanism for authors to provide section titles to help
+              users navigate and identify their location.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met28" name="met28" value="yes"> Yes</label>
+            <label><input type="radio" id="met28" name="met28" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s29">
+            <details open>
+              <summary id="s29">
+              Authors can clearly indicate the target of a hyperlink and
+              function of a control.
+              </summary>
+              <p>
+              Hyperlinks and controls cause changes to the user experience. It
+              is important that users know what change will happen, or what the
+              result of navigating a hyperlink will be. Default or contextual
+              indications may be sufficient for some users but not all.
+              Technologies must provide features allowing authors to
+              unambiguously provide this information.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio"  id="met29" name="met29" value="yes"> Yes</label>
+            <label><input type="radio" id="met29" name="met29" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s30">
+            <details open>
+              <summary id="s30">
+              Authors can indicate content language, for the page as a whole and for blocks of content.
+              </summary>
+              <p>
+             Assistive technology that process language, such as screen readers, braille displays, 
+             and voice input, change according to human language of content. For instance, pronunciation 
+             rules and the effect of certain utterances may change. Technologies need to allow authors 
+             to indicate the language of content, both as a whole and for regions where it differs.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met30" name="met30" value="yes"> Yes</label>
+            <label><input type="radio" id="met30" name="met30" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s31">
+            <details open>
+              <summary id="s31">
+                Authors can support understanding of abbreviations / acronyms / initialisms, idioms, jargon, etc.
+              </summary>
+              <p>
+              Abbreviations, acronyms, initialisms, idioms, and jargon comprise usages of content that 
+              may not be familiar to all users, so it can be helpful for authors to provide supplemental 
+              information about meaning. Abbreviations, acronyms, and initialisms are also often frequently 
+              pronounced different from their spelling, their special nature may not be obvious from pronunciation alone. 
+              Therefore technologies should allow authors to provide pronunciation and meaning guidance for these language features.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met31" name="met31" value="yes"> Yes</label>
+            <label><input type="radio" id="met31" name="met31" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s32">
+            <details open>
+              <summary id="s32">
+                Authors can support correct machine pronunciation of ambiguously spelled terms (e.g., in the phrase "I am content with this content" there are different correct pronunciations of the lexeme "content").
+              </summary>
+              <p>
+              Many languages have lexical features that can be pronounced different ways and that carry different meanings. Context generally clarifies intent, but this can be less effective when assistive technologies use default pronunciations. Therefore technologies should provide features to allow authors to clarify pronunciation intent when needed.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met32" name="met32" value="yes"> Yes</label>
+            <label><input type="radio" id="met32" name="met32" value="no"> No</label>
+          </td>
+        </tr>
+         <tr>
+          <th scope="row" aria-labelledby="s33">
+            <details open>
+              <summary id="s33">
+                Authors can identify regions of content, particularly the "main" region.
+              </summary>
+              <p>
+              Users of some assistive technologies experience content in a linear fashion, which can make it hard to find intended content that is located after several blocks of less relevant content such as navigation and sidebars. Other users have difficulty making sense of the page design due to complexity or the effects of magnification. Supporting users to find relevant content quickly is important to effective use, and the best way to do this is to provide ways to identify regions of content easily. This can be done via headings but region type semantics is also particularly helpful. The main content region is the most important for users to find quickly, but other regions such as navigation, headers, footers, sidebars, and subsections are also important. Technologies should provide features to allow authors to identify content regions.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met33" name="met33" value="yes"> Yes</label>
+            <label><input type="radio" id="met33" name="met33" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s34">
+            <details open>
+              <summary id="s34">
+                Declarative mechanisms (that have accessibility semantics pre-defined in the spec) are used to implement technology features whenever possible.
+              </summary>
+              <p>
+              Declarative technologies create sets of pre-defined semantics that authors use to structure content. Because the semantics are well-defined, they can be broadly supported across the entire tool chain, including by assistive technologies. Imperative technologies, by contrast, don't define semantics in advance, which allows creation of new forms of content but requires authors to implement all aspects of the user experience, including accessibility aspects that are frequently overlooked. For this reason, technologies should provide declarative semantics for known feature types.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met34" name="met34" value="yes"> Yes</label>
+            <label><input type="radio" id="met34" name="met34" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s35">
+            <details open>
+              <summary id="s35">
+                There are unambiguous ways to express relationships between units of content, such as object nesting, ID referencing, etc.
+              </summary>
+              <p>
+              Providing an accessible user experience sometimes requires tools to combine the features of or support rapid navigation between multiple related objects. Technologies should provide ways for authors to define these relationships clearly and unambiguously.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met35" name="met35" value="yes"> Yes</label>
+            <label><input type="radio" id="met35" name="met35" value="no"> No</label>
+          </td>
+        </tr>
+         <tr>
+          <th scope="row" aria-labelledby="s36">
+            <details open>
+              <summary id="s36">
+                Prefer structural semantics to presentational semantics.
+              </summary>
+              <p>
+              Structural semantics provide information about the role of content within the whole, while presentational semantics define intended presentation. Authors frequently use presentation to convey structure, yet when taken out of context this presentation is not meaningful to all users. Technologies should emphasize structural semantics over presentational semantics, and support styling on the basis of structure rather than inferring structure on the basis of style.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met36" name="met36" value="yes"> Yes</label>
+            <label><input type="radio" id="met36" name="met36" value="no"> No</label>
+          </td>
+        </tr>
+         <tr>
+          <th scope="row" aria-labelledby="s37">
+            <details open>
+              <summary id="s37">
+               When providing presentational semantics, they can be easily mapped to structural semantics, e.g., to support restyling or meaningful exposure to accessibility APIs.
+              </summary>
+              <p>
+              If technologies do provide presentational semantics, they should define clear mappings to existing structural semantics as well, allowing users to interact with content on the basis of implied structure.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met37" name="met37" value="yes"> Yes</label>
+            <label><input type="radio" id="met37" name="met37" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s38">
+            <details open>
+              <summary id="s38">
+               Support a comprehensive set of authoring use cases to minimize the need for alternative content. (e.g., don't make authors resort to text in images to get the style they want).
+              </summary>
+              <p>
+              Many accessibility problems in web content arise from authors attempting to work around limitations of the content language and using the technology in a way that it was not intended. Technologies should provide rich feature sets that allows authors to accomplish their goals without resort to inaccessible usages.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met38" name="met38" value="yes"> Yes</label>
+            <label><input type="radio" id="met38" name="met38" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s39">
+            <details open>
+              <summary id="s39">
+               Semantics allow precise and replicable location information in the document to be determined.
+              </summary>
+              <p>
+              Finding a given location in a document is important for a variety of use cases. Users of some assistive technologies require the tool to navigate to the location for them and may be confused if the location is merely approximate. Technologies should enable precise location finding, not only by supporting unique IDs but by structuring the language such that unambiguous and replicable selectors can be used and shared.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met39" name="met39" value="yes"> Yes</label>
+            <label><input type="radio" id="met39" name="met39" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s40">
+            <details open>
+              <summary id="s40">
+               Semantics exist to convey meaning that is commonly conveyed via presentation.
+              </summary>
+              <p>
+              Meaning is conveyed by a variety of presentational attributes. Separated blocks of text represent paragraphs, indented text represents quotes, short enlarged text indicates headings, bold text conveys emphasis, relative size indicates relative importance, etc. Technologies should define structural semantics for such features.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met40" name="met40" value="yes"> Yes</label>
+            <label><input type="radio" id="met40" name="met40" value="no"> No</label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+           If technology provides time-based visual media (see also the
+        <a
+          href="https://www.w3.org/WAI/PF/HTML/wiki/Media_Accessibility_Checklist"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Media Accessibility Checklist</a>)
+        </legend>
+        
+         <input type="radio" id="q6_yes" name="q6" value="Yes" required aria-describedby="q6Description" checked />
+         <label for="q6_yes">Yes</label>
+         <input type="radio" id="q6_no" name="q6" value="No" required aria-describedby="q6Description" />
+         <label for="q6_no">No</label>
+
+        <details>
+            <summary>
+                Time-based visual media checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides time-based visual media checklist"
+      id="table6"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s41">
+            <details open>
+              <summary id="s41">
+              It is possible for authors to provide detailed text descriptions, audio descriptions, or both of the important content in the media.
+              </summary>
+              <p>
+              Some visual media cannot at present be made directly accessible to some users. Accessibility is provided via text or audio descriptions, either as part of the content or as an easily found supplementary resource. Technologies should provide mechanisms to provide these descriptions and associate them with the media.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met41" name="met41" value="yes"> Yes</label>
+            <label><input type="radio" id="met41" name="met41" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s42">
+            <details open>
+              <summary id="s42">
+              It is possible for authors to synchronize descriptions with the visual content.
+              </summary>
+              <p>
+              Descriptions are sometimes more helpful when they can be accessed along with the main video content. Technologies should provide a mechanism to synchronize descriptions, e.g., via additional audio tracks, timed text, etc.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met42" name="met42" value="yes"> Yes</label>
+            <label><input type="radio" id="met42" name="met42" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s43">
+            <details open>
+              <summary id="s43">
+              It is possible for to provide descriptions even when the content is live.
+              </summary>
+              <p>
+              It is harder to provide descriptions for live content, because the description must be produced at the same time as the content itself. Nonetheless, for some live content such as newscasts with a broad audience, this can be an important feature. Technologies should provide support for live descriptions.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met43" name="met43" value="yes"> Yes</label>
+            <label><input type="radio" id="met43" name="met43" value="no"> No</label>
+          </td>
+        </tr>
+          <tr>
+          <th scope="row" aria-labelledby="s44">
+            <details open>
+              <summary id="s44">
+              User can pause, stop, replay media.
+              </summary>
+              <p>
+              While most media can be stopped (where replay restarts from the beginning) or paused (where replay restarts from where it starts), the controls to do so can be inaccessible to users. Technologies need to provide accessible controls to do this, and also support programmatic control so assistive technologies can pause, stop, and start media playback. This support is important even for media that is not generally intended to be used in this way, such as short autoplay clips, in order to provide users control over excessive distraction.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met44" name="met44" value="yes"> Yes</label>
+            <label><input type="radio" id="met44" name="met44" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s45">
+            <details open>
+              <summary id="s45">
+              Users can send output to alternate device.
+              </summary>
+              <p>
+             Some users use multiple video or audio devices to tune their accessible interaction. For instance, a screen reader user may direct content audio to a different device than screen reader audio in order to reduce collision, or a magnifier user may direct video to a separate screen in order to better arrange their available screen space. Technologies should provide features to support this.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met45" name="met45" value="yes"> Yes</label>
+            <label><input type="radio" id="met45" name="met45" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+      <fieldset>
+         <legend>
+          If technology provides audio
+        </legend>
+        
+         <input type="radio" id="q7_yes" name="q7" value="Yes" required aria-describedby="q7Description" checked />
+         <label for="q7_yes">Yes</label>
+         <input type="radio" id="q7_no" name="q7" value="No" required aria-describedby="q7Description" />
+         <label for="q7_no">No</label>
+
+        <details>
+            <summary>
+                Audio checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides audio checklist"
+      id="table7"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s46">
+            <details open>
+              <summary id="s46">
+              It is possible for authors to provide transcriptions.
+              </summary>
+              <p>
+              Like descriptions of video, transcriptions of audio is important
+              for some users. Authors should be able to provide text transcripts
+              or signed video alternatives and associate them directly with the
+              primary content.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met46" name="met46" value="yes"> Yes</label>
+            <label><input type="radio" id="met46" name="met46" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s47">
+            <details open>
+              <summary id="s47">
+              It is possible for authors to provide synchronized captions,
+              either open (on by default for all users).
+              </summary>
+              <p>
+              Captions are essentially text transcripts that are synchronized to
+              appear in small blocks when the relevant audio is playing. Closed
+              captions are visible only on request, and are best provided in a
+              timed text track although they are sometimes provide in a separate
+              video track. Open captions are included directly within the source
+              video. Technologies should provide features to allow authors to
+              create closed and open captions.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met47" name="met47" value="yes"> Yes</label>
+            <label><input type="radio" id="met47" name="met47" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s48">
+            <details open>
+              <summary id="s48">
+              User can adjust volume level
+              </summary>
+              <p>
+              Some users require different volume levels than default, and may
+              need the relative volume of different elements to be different.
+              Technologies should provide ways for users to adjust the volume of
+              audio content within the content, not simply relying on hardware
+              volume settings.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met48" name="met48" value="yes"> Yes</label>
+            <label><input type="radio" id="met48" name="met48" value="no"> No</label>
+          </td>
+        </tr>
+          <tr>
+          <th scope="row" aria-labelledby="s49">
+            <details open>
+              <summary id="s49">
+              Contrast between foreground and background audio is sufficient
+              </summary>
+              <p>
+              Understanding of audio is improved when background sounds do not
+              occlude foreground or primary audio. To support this, authors
+              should be able to set background and foreground levels separately.
+              Ideally, users should also be able to adjust them separately via
+              separate audio tracks.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met49" name="met49" value="yes"> Yes</label>
+            <label><input type="radio" id="met49" name="met49" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s50">
+            <details open>
+              <summary id="s50">
+              Unnecessary background audio can be muted separately from the
+              foreground audio
+              </summary>
+              <p>
+              When background audio makes understanding of content too
+              difficult, users should be able to suppress it without losing the
+              foreground audio. Technologies should provide features to make
+              this possible, e.g., via support of multiple audio tracks.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met50" name="met50" value="yes"> Yes</label>
+            <label><input type="radio" id="met50" name="met50" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s51">
+            <details open>
+              <summary id="s51">
+              Technology does not include triggers for audiosensitive seizures or allows those triggers to be disabled.
+              </summary>
+              <p>
+              Like photosensitive epilepsy, audiosensitive epilepsy is known to occur. The triggering conditions are less widely known at this time, but nonetheless technologies should avoid enabling authoring of triggering content, or provide means to detect, warn, avoid, and suppress triggering content.
+              </p>
+            </details>
+          </th>
+          <td> </td>
+          
+          <td class="met-column">
+            <label><input type="radio" id="met51" name="met51" value="yes"> Yes</label>
+            <label><input type="radio" id="met51" name="met51" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology allows time limits
+        </legend>
+        
+         <input type="radio" id="q8_yes" name="q8" value="Yes" required aria-describedby="q8Description" checked />
+        <label for="q8_yes">Yes</label>
+        <input type="radio" id="q8_no" name="q8" value="No" required aria-describedby="q8Description" />
+        <label for="q8_no">No</label>
+
+        <details>
+            <summary>
+                Time limits checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology allows time limits checklist"
+      id="table8"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s52">
+            <details open>
+              <summary id="s52">
+              A feature exists to allow time limits to be extended.
+              </summary>
+              <p>
+              Because of the additional time cost to using assistive technologies, or because of difficulty processing content, some users need more time to accomplish tasks than average. Common time limits can be time for response before a login session expires, or time before content automatically refreshes or changes. When technologies allow authors to set time limits, they should provide ways for users to request extensions to the time limit - before the expiration of the limit causes a disastrous interruption to their use. Some content does require a time limit, such as financial transactions or testing, so technologies should also allow authors or test proctors to define limits for how much extension users should be able to obtain.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met52" name="met52"  value="yes"> Yes</label>
+            <label><input type="radio" id="met52" name="met52"  value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s53">
+            <details open>
+              <summary id="s53">
+              Time limits for different parts of a task, such as reading instructions vs providing input, can be set separately.
+              </summary>
+              <p>
+              Different activities require different amounts of time for different users. Technologies should allow authors to set time limits in a fine-grained manner when needed.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met53" name="met53" value="yes"> Yes</label>
+            <label><input type="radio" id="met53" name="met53" value="no"> No</label>
+          </td>
+        </tr>
+        
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+         If technology allows text content
+        </legend>
+        
+        <input type="radio" id="q9_yes" name="q9" value="Yes" required aria-describedby="q9Description" checked />
+        <label for="q9_yes">Yes</label>
+        <input type="radio" id="q9_no" name="q9" value="No" required aria-describedby="q9Description" />
+        <label for="q9_no">No</label>
+        <details>
+            <summary>
+                Text content checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology allows text content checklist"
+      id="table9"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s54">
+            <details open>
+              <summary id="s54">
+              Authors can define non-text alternatives for text content.
+              </summary>
+              <p>
+              While text is the universal accessible alternative, it is still
+              not the best format for some users. Technologies should allow
+              authors to provide non-text alternatives to text content when
+              needed. Various types of alternatives are useful in different
+              situations, including visual such as icons or movies, auditory
+              such as pronunciation cues and recorded speech, and haptic.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met54" name="met54" value="yes"> Yes</label>
+            <label><input type="radio" id="met54" name="met54" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s55">
+            <details open>
+              <summary id="s55">
+              Authors can define non-text alternatives for non-text content.
+              </summary>
+              <p>
+              Even though text alternatives for non-text content is generally
+              recommended, in some situations a non-text alternative is more
+              suitable. For instance, a haptic version of a map, in which
+              features are conveyed by touch features, can be easier to
+              understand than a text alternative. Technologies should allow
+              authors to provide these enhance alternatives in addition to text
+              alternatives.
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met55" name="met55" value="yes"> Yes</label>
+            <label><input type="radio" id="met55" name="met55" value="no"> No</label>
+          </td>
+        </tr>
+        
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology creates objects that don't have an inherent text
+        representation
+        </legend>
+        
+        <input type="radio" id="q10_yes" name="q10" value="Yes" required aria-describedby="q10Description" checked />
+      <label for="q10_yes">Yes</label>
+      <input type="radio" id="q10_no" name="q10" value="No" required aria-describedby="q10Description" />
+      <label for="q10_no">No</label>
+
+        <details>
+            <summary>
+                 Objects that don't have an inherent text representation checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology creates objects that don't have an inherent text representation checklist"
+      id="table10"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s56">
+            <details open>
+              <summary id="s56">
+             There is a mechanism to create short text alternatives that label the object.
+              </summary>
+              <p>
+              Some non-text objects can be represented as text, such as form controls, user interface objects, etc. Authors have no inherent text version that can be meaningfully exposed to the user. In this case, technologies should allow authors to provide a short label for the object.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met56" name="met56" value="yes"> Yes</label>
+            <label><input type="radio" id="met56" name="met56" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s57">
+            <details open>
+              <summary id="s57">
+              There is a mechanism to create extended text alternatives for fallback content.
+              </summary>
+              <p>
+             In addition to labels, authors should be able to provide extended text alternatives to better describe non-text objects. Technologies should provide a feature for this extended description that is distinct from the short label, and that can be associated with the object.
+             </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met57" name="met57" value="yes"> Yes</label>
+            <label><input type="radio" id="met57" name="met57" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s58">
+            <details open>
+              <summary id="s58">
+              Text alternatives can be semantically "rich" e.g., with page structure, text style, hyperlinks, etc.
+              </summary>
+              <p>
+             Extended text alternatives should allow authors to use, and users to benefit from, full text semantics rather than reduce them to plain text.
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met58" name="met58" value="yes"> Yes</label>
+            <label><input type="radio" id="met58" name="met58" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+       <fieldset>
+         <legend>
+         If technology provides content fallback mechanisms, whether text or
+        other formats
+        </legend>
+        
+       <input type="radio" id="q11_yes" name="q11" value="Yes" required aria-describedby="q11Description" checked />
+      <label for="q11_yes">Yes</label>
+      <input type="radio" id="q11_no" name="q11" value="No" required aria-describedby="q11Description" />
+      <label for="q11_no">No</label>
+
+        <details>
+            <summary >
+                 Content fallback mechanisms checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides content fallback mechanisms, whether text or other formats checklist"
+      id="table11"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s59">
+            <details open>
+              <summary id="s59">
+             Authors can explicitly mark content as not needing alternative content because it does not perform an important role.
+              </summary>
+              <p>
+              Some non-text content does not require an alternative version because it does not perform a function important to understanding the overall content, such as objects to facilitate layout, add graphical interest, etc. In order to avoiding requiring users to determine their role, technologies should provide a mechanism for authors to state explicitly that the object does not require an alternate version
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met59" name="met59" value="yes"> Yes</label>
+            <label><input type="radio" id="met59" name="met59" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s60">
+            <details open>
+              <summary id="s60">
+              Content can explicitly indicate when author declined to provide alternative content.
+              </summary>
+              <p>
+             Sometimes authoring tools prompt authors to provide alternative content, but they do not do so. Technologies should provide a feature to allow the user to be notified that the author chose not to provide alternative content.
+             </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met60" name="met60" value="yes"> Yes</label>
+            <label><input type="radio" id="met60" name="met60" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s61">
+            <details open>
+              <summary id="s61">
+              Content can explicitly indicate that authoring tool is unable to generate or obtain alternative content.
+              </summary>
+              <p>
+             Some authoring tools attempt to generate alternate content, but are not always able to. Technologies should allow tools to indicate to users that they were not able to generate alternate content.
+             </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met61" name="met61" value="yes"> Yes</label>
+            <label><input type="radio" id="met61" name="met61" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s62">
+            <details open>
+              <summary id="s62">
+              Authors can explicitly associate alternative content with the primary content.
+              </summary>
+              <p>
+             Technologies should enable authors to associate alternative content unambiguously with the main content.
+             </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met62" name="met62" value="yes"> Yes</label>
+            <label><input type="radio" id="met62" name="met62" value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s63">
+            <details open>
+              <summary id="s63">
+              Authors can associate multiple types and instances of alternative content with primary content.
+              </summary>
+              <p>
+             Sometimes, it is appropriate for authors to provide multiple forms of alternate content. Technologies should allow more than one unit of alternate content to be associated with a given object.
+             </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met63" name="met63"  value="yes"> Yes</label>
+            <label><input type="radio" id="met63" name="met63"  value="no"> No</label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row" aria-labelledby="s64">
+            <details open>
+              <summary id="s64">
+              Alternate content can be easily found from the initial content.
+              </summary>
+              <p>
+            Replaces, referenced directly from, at same location of initial content.
+            </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met64" name="met64" value="yes"> Yes</label>
+            <label><input type="radio" id="met64" name="met64" value="no"> No</label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology provides visual graphics
+        </legend>
+        
+        <input type="radio" id="q12_yes" name="q12" value="Yes" required aria-describedby="q12Description" checked />
+      <label for="q12_yes">Yes</label>
+      <input type="radio" id="q12_no" name="q12" value="No" required aria-describedby="q12Description" />
+      <label for="q12_no">No</label>
+
+        <details>
+            <summary>
+                 Visual graphics checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides visual graphics checklist"
+      id="table12"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s65">
+            <details open>
+              <summary id="s65">
+             Item
+              </summary>
+              <p>
+             This is a developing area, being explored by the
+              <a
+                href="https://www.w3.org/WAI/PF/svg-a11y-tf/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                SVG Accessibility Task Force.
+              </a>
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met65" name="met65" value="yes"> Yes</label>
+            <label><input type="radio" id="met65" name="met65" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology provides internationalization support
+        </legend>
+        
+        <input type="radio" id="q13_yes" name="q13" value="Yes" required aria-describedby="q13Description" checked />
+      <label for="q13_yes">Yes</label>
+      <input type="radio" id="q13_no" name="q13" value="No" required aria-describedby="q13Description" />
+      <label for="q13_no">No</label>
+
+        <details>
+            <summary>
+                 Internationalization support
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides internationalization support checklist"
+      id="table13"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s66">
+            <details open>
+              <summary id="s66">
+             Accessibility features can be internationalized to the same degree as other features
+              </summary>
+              <p>
+              Technologies that support internationalization must not overlook
+              accessibility features. In particular for content alternatives,
+              technologies should support including multiple language
+              alternatives, language identification and changes within
+              alternative content, text directionality identification, etc.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met66" name="met66" value="yes"> Yes</label>
+            <label><input type="radio" id="met66" name="met66" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology defines accessible alternative features
+        </legend>
+        
+        <input type="radio" id="q14_yes" name="q14" value="Yes" required aria-describedby="q14Description" checked />
+      <label for="q14_yes">Yes</label>
+      <input type="radio" id="q14_no" name="q14" value="No" required aria-describedby="q14Description" />
+      <label for="q14_no">No</label>
+
+        <details>
+            <summary>
+                 Accessible alternative features checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology defines accessible alternative features checklist"
+      id="table14"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s67">
+            <details open>
+              <summary id="s67">
+             Accessible alternatives themselves meet the same bar of accessibility.
+              </summary>
+              <p>
+              For instance, captions should be able to have color and style
+              changed by the user. Text alternatives should allow rich content.
+              Audio descriptions should be separable from other sound.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met67" name="met67" value="yes"> Yes</label>
+            <label><input type="radio" id="met67" name="met67" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+      <fieldset>
+         <legend>
+          If technology provides content directly for end-users
+        </legend>
+        
+        <input type="radio" id="q15_yes" name="q15" value="Yes" required aria-describedby="q15Description" checked/>
+      <label for="q15_yes">Yes</label>
+      <input type="radio" id="q15_no" name="q15" value="No" required aria-describedby="q15Description" />
+      <label for="q15_no">No</label>
+
+        <details>
+            <summary>
+                 If technology provides content directly for end-users checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology provides content directly for end-users checklist"
+      id="table15"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s68">
+            <details open>
+              <summary id="s68">
+             Content can be encoded in a manner that allows machine transformation into accessible output
+              </summary>
+              <p>
+              Some technologies encode content into a binary format that
+              requires specific software to execute and render the content.
+              Unless that format provide robust interaction with accessibility
+              APIs and comprehensive transformation support, this will reduce
+              the scope of accessible transformation that could be possible for
+              the content. Technologies should choose content formats that allow
+              easy transformation including from third-party tools and services.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met68" name="met68" value="yes"> Yes</label>
+            <label><input type="radio" id="met68" name="met68" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+       <fieldset>
+         <legend>
+          If technology defines an API
+        </legend>
+        
+        <input type="radio" id="q16_yes" name="q16" value="Yes" required aria-describedby="q16Description" checked />
+      <label for="q16_yes">Yes</label>
+      <input type="radio" id="q16_no" name="q16" value="No" required aria-describedby="q16Description" />
+      <label for="q16_no">No</label>
+
+        <details>
+            <summary>
+                 API checklist
+            </summary>
+
+    <table
+      role="table"
+      aria-label="If technology defines an API checklist"
+      id="table16"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+    
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s69">
+            <details open>
+              <summary id="s69">
+             If the API relies on user agents to generate a user interface, the specification provides guidance about accessibility requirements needed to enable full interaction with the API.
+              </summary>
+              <p>
+              Content manipulated by an API is generally generated into a user interface. Technologies should provide guidance to ensure that user agents or dynamic content applications expose the full set of accessibility information available in the API.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met69" name="met69" value="yes"> Yes</label>
+            <label><input type="radio" id="met69" name="met69" value="no"> No</label>
+          </td>
+        </tr>
+       
+      </tbody>
+    </table>
+  </details>
+      </fieldset>
+
+
+
+     <fieldset>
+        <legend>
+             If technology defines a transmission protocol
+        </legend>
+
+  <input type="radio" id="q17_yes" name="q17" value="Yes" required aria-describedby="q17Description" checked />
+  <label for="q17_yes">Yes</label>
+  <input type="radio" id="q17_no" name="q17" value="No" required aria-describedby="q17Description" />
+  <label for="q17_no">No</label>
+
+  <details>
+    <summary>
+      Transmission protocol checklist
+    </summary>
+
+    <table
+      role="table"
+      aria-label="If technology defines a transmission protocol checklist"
+      id="table17"
+    >
+      <thead>
+        <tr>
+          <th scope="col">Checkpoint</th>
+          <th scope="col">References</th>
+          <th scope="col">Met?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row" aria-labelledby="s70">
+            <details open>
+              <summary id="s70">
+                Use of the protocol does not cause any aspect of the content,
+                including metadata which could contain important accessibility
+                information, to be removed.
+              </summary>
+              <p>
+                Transmission protocols exchange content between devices.
+                Sometimes protocols remove content viewed as unimportant, or
+                restrict what can be transmitted for security or provenance
+                reasons. This can have unintended impacts on accessibility
+                features in the content. Technologies defining transmission
+                profiles need to ensure all aspects of the content relevant to
+                accessibility are included.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met70" name="met70" value="yes"> Yes</label>
+            <label><input type="radio" id="met70" name="met70" value="no"> No</label>
+          </td>
+        </tr>
+
+        <tr>
+          <th scope="row" aria-labelledby="s71">
+            <details open>
+              <summary id="s71">
+                It is possible to use third-party accessibility enhancement
+                services while using the protocol.
+              </summary>
+              <p>
+                On the Web, content is typically exchanged between a client and
+                server. For accessibility, some third-party tools may act
+                between these endpoints to modify the content to a form that is
+                more suitable for the user. While transmission protocols need
+                to avoid unintended modification of the stream, they also need
+                to provide support for this use case.
+              </p>
+            </details>
+          </th>
+          <td></td>
+          <td class="met-column">
+            <label><input type="radio" id="met71" name="met71" value="yes"> Yes</label>
+            <label><input type="radio" id="met71" name="met71" value="no"> No</label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </details>
+</fieldset>
+
+<button id="createIssueBtn" type="submit" aria-describedby="submit-caveat">Create issue</button>
+<span id="submit-caveat" class="note"><strong>Note: </strong>The markdown will be copied to your clipboard. You can paste it into the Github issue directly.</span>
+
+    <script src="checklist.js"></script>
+    </main>
+  </body>
 </html>

--- a/checklist.html
+++ b/checklist.html
@@ -15,6 +15,7 @@
 			.checklist
 			{
 				list-style-type: checklist;
+				
 			}
 			.checklist ul
 			{

--- a/checklist.js
+++ b/checklist.js
@@ -1,0 +1,183 @@
+document.addEventListener("DOMContentLoaded", () => {
+  initFieldsetDetails();
+  initClipboardButton();
+});
+
+// Initialize Yes/No toggle for <details>
+function initFieldsetDetails() {
+  document.querySelectorAll("fieldset").forEach(fieldset => {
+    const yesRadio = fieldset.querySelector('input[type="radio"][value="Yes"]');
+    const noRadio = fieldset.querySelector('input[type="radio"][value="No"]');
+    const details = fieldset.querySelector("details");
+    if (!yesRadio || !noRadio || !details) return;
+
+    function updateDetails() {
+      details.open = yesRadio.checked;
+    }
+    yesRadio.addEventListener("change", updateDetails);
+    noRadio.addEventListener("change", updateDetails);
+    updateDetails();
+  });
+}
+
+// Initialize Copy to Clipboard button
+function initClipboardButton() {
+  document.getElementById("createIssueBtn").addEventListener("click", (ev) => {
+    ev.preventDefault && ev.preventDefault();
+
+    const specName = document.getElementById("spec-name");
+    const specUrl = document.getElementById("spec-url");
+
+    //Validate fields
+    if(specName && specUrl){
+      const isValid = specName.checkValidity() && specUrl.checkValidity();
+      if(!isValid){
+        specName.reportValidity();
+        specUrl.reportValidity();
+        return;
+      }
+    }
+
+    const markdown = buildMarkdown();
+
+    navigator.clipboard
+      .writeText(markdown)
+      .then(() => handleClipboardSuccess(markdown))
+      .catch(err => handleClipboardError(markdown, err));
+  });
+}
+
+function buildMarkdown() {
+  let markdown = "";
+
+  document.querySelectorAll("fieldset").forEach(fieldset => {
+    const legend = containerToMarkdown(fieldset.querySelector("legend")) || "Fieldset";
+    const yesRadio = fieldset.querySelector('input[type="radio"][value="Yes"]');
+    const details = fieldset.querySelector("details");
+    if (!details) return;
+
+    const isYes = yesRadio?.checked;
+    const summaryText = containerToMarkdown(details.querySelector("summary")) || "";
+
+    markdown += `### ${legend}\n\n`;
+    markdown += `<details${isYes ? " open" : ""}>\n`;
+    markdown += `<summary>${summaryText}</summary>\n\n`;
+
+    const table = details.querySelector("table");
+    markdown += table ? buildTableMarkdown(table) : "_No checklist available_\n";
+
+    markdown += `\n</details>\n\n`;
+  });
+
+  return markdown;
+}
+
+// Build markdown for a table
+function buildTableMarkdown(table) {
+  let markdown = "";
+
+  const headers = Array.from(table.querySelectorAll("thead th"))
+    .map(th => containerToMarkdown(th))
+    .join(" | ");
+  const separators = Array.from(table.querySelectorAll("thead th"))
+    .map(() => "---")
+    .join(" | ");
+
+  markdown += `| ${headers} |\n`;
+  markdown += `| ${separators} |\n`;
+
+  table.querySelectorAll("tbody tr").forEach(tr => {
+    const cells = Array.from(tr.querySelectorAll("td, th")).map(td => formatTableCell(td));
+    markdown += `| ${cells.join(" | ")} |\n`;
+  });
+
+  return markdown;
+}
+
+// Format individual table cell
+function formatTableCell(td) {
+  let text = "";
+
+  if (td.classList.contains("met-column")) {
+    const yesRadio = td.querySelector('input[type="radio"][value="yes"]');
+    text = yesRadio?.checked ? "Yes" : "No";
+  } else if (td.tagName === "TH") {
+    const detailsElement = td.querySelector("details");
+    if (detailsElement) {
+      text = convertDetailsElement(detailsElement);
+    } else {
+      text = containerToMarkdown(td);
+    }
+  } else {
+    text = containerToMarkdown(td);
+  }
+
+  return text;
+}
+
+// Convert <details> element to Markdown with links in <a>
+function convertDetailsElement(detailsElement) {
+  const cloned = detailsElement.cloneNode(true);
+  cloned.removeAttribute("open"); // Closed by default
+
+  // Convert all <a> tags to markdown
+  cloned.querySelectorAll("a").forEach(a => {
+    const mdLink = `[${a.textContent.trim()}](${a.href})`;
+    a.replaceWith(mdLink);
+  });
+
+  const pElements = cloned.querySelectorAll("p");
+  pElements.forEach(p => {
+    const pContent = p.innerHTML.replace(/\s*\n\s*/g, " ").trim();
+    p.innerHTML = `*${pContent}*`;
+  });
+  return cloned.outerHTML.replace(/\s*\n\s*/g, " ").trim();
+}
+
+// Convert container (text nodes + links) to markdown
+function containerToMarkdown(container) {
+  if (!container) return "";
+
+  let md = "";
+  container.childNodes.forEach(node => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      md += node.textContent.trim() + " ";
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node.tagName === "A") {
+        md += `[${node.textContent.trim()}](${node.href}) `;
+      } else {
+        md += containerToMarkdown(node) + " ";
+      }
+    }
+  });
+
+  return md.replace(/\s+/g, " ").trim();
+}
+
+// Clipboard success handler
+function handleClipboardSuccess(markdown) {
+  const repoUrl = document.getElementById("spec-repo")?.value.trim();
+  const issueTitle = "FAST checklist";
+
+  if (!repoUrl || !validateGitHubRepoUrl(repoUrl)) {
+    alert("Please enter a valid GitHub repository URL in the format 'https://github.com/<org>/<repo>'.");
+    return;
+  }
+
+  alert("Markdown copied to clipboard!");
+  const issueBody = `<!-- The markdown content has been copied to your clipboard. Please paste it here -->`;
+  const cleanUrl = repoUrl.replace(/\/+$/, "");
+  window.location.href = `${cleanUrl}/issues/new?title=${encodeURIComponent(issueTitle)}&body= ${encodeURIComponent(issueBody)}`;
+}
+
+// Clipboard error handler
+function handleClipboardError(markdown, err) {
+  console.error("Failed to copy:", err);
+  window.prompt("Copy the markdown below (Ctrl/Cmd+C):", markdown);
+}
+
+// Validate GitHub repo URL
+function validateGitHubRepoUrl(repoUrl) {
+  const regex = /^https:\/\/github\.com\/([^\/]+)\/([^\/\?]+)[\/\?]?/;
+  return regex.test(repoUrl);
+}


### PR DESCRIPTION
Hello all,

This draft PR implements the transition to HTML form for the FAST checklist.

Note that this is one of the 2 versions that is being worked on.

- **Current version** - The results of the form will be copied to the clipboard in a **table** format, matching the appearance of the HTML form, which could then be pasted into a Github issue in your spec's repository.
- **Second version** - The results of the form are copied to the clipboard in a **list** format, which can then be pasted into a GitHub issue in your spec's repository. Here's the [DRAFT PR](https://github.com/w3c/fast/pull/20) for the gh-list version.

What remains the same across both versions is the HTML form itself. The difference lies only in how the results are copied to the clipboard.

You can preview the form here: https://raw.githack.com/w3c/fast/html-form-github-table/checklist.html